### PR TITLE
fix: Remove getTasks from funtion return of composable

### DIFF
--- a/src/composables/useIndex.ts
+++ b/src/composables/useIndex.ts
@@ -42,8 +42,7 @@ export default () => {
   return {
     pending,
     tasks,
-    
-    getTasks,
+
     removeTask
   }
 }

--- a/src/views/Index.vue
+++ b/src/views/Index.vue
@@ -7,14 +7,14 @@ export default defineComponent({
     const {
       pending,
       tasks,
-    
-      getTasks,
+
       removeTask
     } = useIndex()
 
     return {
       pending,
       tasks,
+
       removeTask
     }
   }


### PR DESCRIPTION
fix: Remove getTasks from funtion return of composable